### PR TITLE
Adding support for stripWWW and stripFragments

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,15 @@
 'use strict';
-var arrayUniq = require('array-uniq');
-var urlRegex = require('url-regex');
-var normalizeUrl = require('normalize-url');
+var arrayUniq    = require('array-uniq'),
+    urlRegex     = require('url-regex'),
+    normalizeUrl = require('normalize-url'),
+    objectAssign = require('object-assign');
 
-module.exports = function (str) {
+module.exports = function (str, opts) {
+  opts = objectAssign({
+    stripWWW: true,
+    stripFragment: true,
+  }, opts);
+
 	var urls = str.match(urlRegex());
 
 	if (!urls) {
@@ -11,6 +17,6 @@ module.exports = function (str) {
 	}
 
 	return arrayUniq(urls.map(function (url) {
-		return normalizeUrl(url.trim().replace(/\.*$/, ''));
+		return normalizeUrl(url.trim().replace(/\.*$/, ''), opts);
 	}));
 };

--- a/index.js
+++ b/index.js
@@ -1,15 +1,9 @@
 'use strict';
-var arrayUniq    = require('array-uniq'),
-    urlRegex     = require('url-regex'),
-    normalizeUrl = require('normalize-url'),
-    objectAssign = require('object-assign');
+var arrayUniq = require('array-uniq');
+var urlRegex = require('url-regex');
+var normalizeUrl = require('normalize-url');
 
 module.exports = function (str, opts) {
-  opts = objectAssign({
-    stripWWW: true,
-    stripFragment: true,
-  }, opts);
-
 	var urls = str.match(urlRegex());
 
 	if (!urls) {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "get-stdin": "^4.0.1",
     "meow": "^3.3.0",
     "normalize-url": "1.3.0",
-    "object-assign": "^3.0.0",
     "url-regex": "^3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "array-uniq": "^1.0.0",
     "get-stdin": "^4.0.1",
     "meow": "^3.3.0",
-    "normalize-url": "^1.0.0",
+    "normalize-url": "1.3.0",
+    "object-assign": "^3.0.0",
     "url-regex": "^2.0.3"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -13,14 +13,50 @@ $ npm install --save get-urls
 
 
 ## Usage
-
-```js
+### getUrls(text, [options]);
+```
 var text = 'Lorem ipsum dolor sit amet, sindresorhus.com consectetuer adipiscing http://yeoman.io elit.';
 
 getUrls(text);
 //=> ['http://sindresorhus.com', 'http://yeoman.io']
 ```
 
+### text
+*Required*
+
+Type: `string`
+
+### options
+
+#### stripFragment
+Type: `boolean`
+
+Default: `true`
+
+```
+var text = 'http://www.google.com/document.html#about'
+
+getUrls(text, {stripFragment: true});
+//=> ['http://www.google.com/document.html']
+
+getUrls(text, {stripFragment: false});
+//=> ['http://www.google.com/document.html#about']
+```
+
+#### stripWWW
+Type: `boolean`
+
+Default: `true`
+
+```
+var text = 'http://www.google.com'
+
+getUrls(text, {stripWWW: true});
+//=> ['http://google.com']
+
+getUrls(text, {stripFragment: false});
+//=> ['http://www.google.com']
+```
 
 ## CLI
 

--- a/readme.md
+++ b/readme.md
@@ -29,35 +29,9 @@ Type: `string`
 
 ### options
 
-#### stripFragment
-Type: `boolean`
+Type: `object`
 
-Default: `true`
-
-```
-var text = 'http://www.google.com/document.html#about'
-
-getUrls(text, {stripFragment: true});
-//=> ['http://www.google.com/document.html']
-
-getUrls(text, {stripFragment: false});
-//=> ['http://www.google.com/document.html#about']
-```
-
-#### stripWWW
-Type: `boolean`
-
-Default: `true`
-
-```
-var text = 'http://www.google.com'
-
-getUrls(text, {stripWWW: true});
-//=> ['http://google.com']
-
-getUrls(text, {stripFragment: false});
-//=> ['http://www.google.com']
-```
+This object is passed to [normalize-url](https://github.com/sindresorhus/normalize-url). The properties and their functionality is described in the normalize-url [readme](https://github.com/sindresorhus/normalize-url/blob/master/readme.md).
 
 ## CLI
 

--- a/test.js
+++ b/test.js
@@ -3,15 +3,64 @@ var assert = require('assert');
 var fs = require('fs');
 var getUrls = require('./');
 
-var expected = [
-	'http://google.com',
-	'http://todomvc.com',
-	'http://yeoman.io',
-	'http://twitter.com/sindresorhus',
-	'https://tastejs.com',
-	'http://github.com'
-];
+describe('should find urls in fixture file', function() {
+  var expected = [
+    'http://google.com',
+    'http://todomvc.com',
+    'http://yeoman.io',
+    'http://twitter.com/sindresorhus',
+    'https://tastejs.com',
+    'http://github.com'
+  ];
 
-it('should get unique cleaned-up urls from a string', function () {
-	assert.deepEqual(getUrls(fs.readFileSync('fixture.txt', 'utf8')), expected);
+  it('should get unique cleaned-up urls from a string', function () {
+    assert.deepEqual(getUrls(fs.readFileSync('fixture.txt', 'utf8')), expected);
+  });
+
+});
+
+describe('stripFragment option', function () {
+  it('should not strip fragments when skipFragments is set to false', function() {
+    var text = 'You can read http://www.foobar.com/document.html#about for more info';
+    var expected = ['http://foobar.com/document.html#about'];
+    var actual = getUrls(text, {stripFragment: false});
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should strip fragments when skipFragments is set to true', function() {
+    var text = 'You can read http://www.foobar.com/document.html#about for more info';
+    var expected = ['http://foobar.com/document.html'];
+    var actual = getUrls(text, {stripFragment: true});
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should strip fragments by default if skipFragments is not in opt', function() {
+    var text = 'You can read http://www.foobar.com/document.html#about for more info';
+    var expected = ['http://foobar.com/document.html'];
+    var actual = getUrls(text);
+    assert.deepEqual(actual, expected);
+  });
+});
+
+describe('stripWWW option', function () {
+  it('should not strip www when stripWWW is set to false', function() {
+    var text = 'You can read http://www.foobar.com/document.html for more info';
+    var expected = ['http://www.foobar.com/document.html'];
+    var actual = getUrls(text, {stripWWW: false});
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should strip www when stripWWW is set to true', function() {
+    var text = 'You can read http://www.foobar.com/document.html for more info';
+    var expected = ['http://foobar.com/document.html'];
+    var actual = getUrls(text, {stripWWW: true});
+    assert.deepEqual(actual, expected);
+  });
+
+  it('should strip www by default if stripWWW is not in opt', function() {
+    var text = 'You can read http://www.foobar.com/document.html for more info';
+    var expected = ['http://foobar.com/document.html'];
+    var actual = getUrls(text);
+    assert.deepEqual(actual, expected);
+  });
 });


### PR DESCRIPTION
With this pull requests users of this library can pass in option object
and utilize strip www and strip fragments from the normalize-url
library.

This is done by allowing users to pass in optional option parameter as
follows

    getUrls(text, {stripFragment: false});

and

    getUrls(text, {stripWWW: false});

This change is backwards compatible, where the defaults favor the
functionality as before.

Note that The normalize-url library was updated to 1.3.0.