### PR TITLE
Bump `url-regex`

### DIFF
--- a/fixture.txt
+++ b/fixture.txt
@@ -6,7 +6,7 @@ http://google.com
       sda
       sda
       fsda
-      aaa www.todomvc.com      f
+      aaa //www.todomvc.com      f
       sad
       asdf
       asdf http://yeoman.io ~~~~
@@ -21,7 +21,7 @@ asfasfsad ssadf https://tastejs.com
 
 sdssdfss www.google.com
 
-unt in culpa github.com (ullamco laboris)
+unt in culpa http://github.com (ullamco laboris)
 
 asdffsdfa sdafas adfsad fa sd
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "get-stdin": "^4.0.1",
     "meow": "^3.3.0",
     "normalize-url": "^1.0.0",
-    "url-regex": "^2.0.3"
+    "url-regex": "^3.0.0"
   },
   "devDependencies": {
     "mocha": "*"

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ $ npm install --save get-urls
 ## Usage
 
 ```js
-var text = 'Lorem ipsum dolor sit amet, sindresorhus.com consectetuer adipiscing http://yeoman.io elit.';
+var text = 'Lorem ipsum dolor sit amet, //sindresorhus.com consectetuer adipiscing http://yeoman.io elit.';
 
 getUrls(text);
 //=> ['http://sindresorhus.com', 'http://yeoman.io']


### PR DESCRIPTION
Protocols are now forced due to the removal of strict TLD checking in `url-regex`.