### PR TITLE
Add TypeScript type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import * as NormalizeURL from 'normalize-url';
 
-interface GetURLsOptions extends NormalizeURL.Options {
+interface Options extends NormalizeURL.Options {
 	/**
 	 * Extract URLs that appear as query parameters in the found URLs
 	 *
@@ -14,5 +14,15 @@ interface GetURLsOptions extends NormalizeURL.Options {
 	exclude?: string[];
 }
 
-declare function getUrls(text: string, options?: GetURLsOptions): Set<string>;
-export = getUrls;
+/**
+ * Get all URLs in a string
+ *
+ * @remarks
+ * The URLs will be normalized using normalize-url.
+ *
+ * @param text - The text to match URLs in
+ * @param options - The options to use when normalizing and extracting URLs
+ * @returns A Set containing all URLs found in the string
+ */
+declare function getUrls(text: string, options?: Options): Set<string>;
+export default getUrls;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,21 +1,17 @@
-declare module 'get-urls' {
-	import * as NormalizeURL from 'normalize-url';
+import * as NormalizeURL from 'normalize-url';
 
-	export = get_urls;
+export interface GetURLsOptions extends NormalizeURL.Options {
+	/**
+	 * Extract URLs that appear as query parameters in the found URLs
+	 *
+	 * @default false
+	 */
+	extractFromQueryString?: boolean;
 
-	interface GetURLsOptions extends NormalizeURL.Options {
-		/**
-		 * Extract URLs that appear as query parameters in the found URLs
-		 *
-		 * @default false
-		 */
-		extractFromQueryString?: boolean;
-
-		/**
-		 * Exclude URLs that match URLs in the given array.
-		 */
-		exclude?: string[];
-	}
-
-	function get_urls(text: string, options?: GetURLsOptions): Set<string>;
+	/**
+	 * Exclude URLs that match URLs in the given array.
+	 */
+	exclude?: string[];
 }
+
+export default function getUrls(text: string, options?: GetURLsOptions): Set<string>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import * as NormalizeURL from 'normalize-url';
 
-export interface GetURLsOptions extends NormalizeURL.Options {
+interface GetURLsOptions extends NormalizeURL.Options {
 	/**
 	 * Extract URLs that appear as query parameters in the found URLs
 	 *
@@ -14,4 +14,5 @@ export interface GetURLsOptions extends NormalizeURL.Options {
 	exclude?: string[];
 }
 
-export default function getUrls(text: string, options?: GetURLsOptions): Set<string>;
+declare function getUrls(text: string, options?: GetURLsOptions): Set<string>;
+export = getUrls;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,21 @@
+declare module 'get-urls' {
+	import * as NormalizeURL from 'normalize-url';
+
+	export = get_urls;
+
+	interface GetURLsOptions extends NormalizeURL.Options {
+		/**
+		 * Extract URLs that appear as query parameters in the found URLs
+		 *
+		 * @default false
+		 */
+		extractFromQueryString?: boolean;
+
+		/**
+		 * Exclude URLs that match URLs in the given array.
+		 */
+		exclude?: string[];
+	}
+
+	function get_urls(text: string, options?: GetURLsOptions): Set<string>;
+}

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const getUrlsFromQueryParams = url => {
 	return ret;
 };
 
-module.exports = (text, options = {}) => {
+const getUrls = (text, options = {}) => {
 	if (typeof options.exclude !== 'undefined' && !Array.isArray(options.exclude)) {
 		throw new TypeError('The `exclude` option must be an array');
 	}
@@ -53,3 +53,6 @@ module.exports = (text, options = {}) => {
 
 	return ret;
 };
+
+module.exports = getUrls;
+module.exports.default = getUrls;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,5 @@
+import { expectType } from 'tsd-check';
+import getUrls from '.';
+import * as fs from 'fs';
+
+expectType<Set<string>>(getUrls(fs.readFileSync('fixture.txt', 'utf8')));

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
 		"test": "xo && ava"
 	},
 	"files": [
-		"index.js"
+		"index.js",
+		"index.d.ts"
 	],
 	"keywords": [
 		"get",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"node": ">=8"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test": "xo && ava && tsd-check"
 	},
 	"files": [
 		"index.js",
@@ -36,6 +36,7 @@
 	},
 	"devDependencies": {
 		"ava": "^1.2.1",
+		"tsd-check": "^0.3.0",
 		"xo": "^0.24.0"
 	}
 }


### PR DESCRIPTION
I noticed `normalize-urls` has a `.d.ts`, but this module doesn't. I needed this package for a TS project, and had to write my own, so I decided to share it here if you wanted it.