### PR TITLE
Upgrade dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 const {URL} = require('url');
-const urlRegex = require('url-regex');
+const urlRegex = require('url-regex-safe');
 const normalizeUrl = require('normalize-url');
 
 const getUrlsFromQueryParams = url => {

--- a/index.js
+++ b/index.js
@@ -1,11 +1,10 @@
 'use strict';
-const {URL} = require('url');
 const urlRegex = require('url-regex-safe');
 const normalizeUrl = require('normalize-url');
 
 const getUrlsFromQueryParams = url => {
 	const ret = new Set();
-	const {searchParams} = (new URL(url.replace(/^(\/\/|(www\.))/i, 'http://$2')));
+	const {searchParams} = (new URL(url.replace(/^(?<slashes>\/\/|(?<identifier>www\.))/i, 'http://$2')));
 
 	for (const [, value] of searchParams) {
 		if (urlRegex({exact: true}).test(value)) {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const normalizeUrl = require('normalize-url');
 
 const getUrlsFromQueryParams = url => {
 	const ret = new Set();
-	const {searchParams} = (new URL(url.replace(/^(\/\/|(www\.))/i, 'http://$2')));
+	const {searchParams} = (new URL(url.replace(/^(?:\/\/|(?:www\.))/i, 'http://$2')));
 
 	for (const [, value] of searchParams) {
 		if (urlRegex({exact: true}).test(value)) {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const normalizeUrl = require('normalize-url');
 
 const getUrlsFromQueryParams = url => {
 	const ret = new Set();
-	const {searchParams} = (new URL(url.replace(/^(?<slashes>\/\/|(?<identifier>www\.))/i, 'http://$2')));
+	const {searchParams} = (new URL(url.replace(/^(\/\/|(www\.))/i, 'http://$2')));
 
 	for (const [, value] of searchParams) {
 		if (urlRegex({exact: true}).test(value)) {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
 	],
 	"dependencies": {
 		"normalize-url": "^4.3.0",
-		"re2": "^1.15.4",
 		"url-regex-safe": "0.0.5"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
 	],
 	"dependencies": {
 		"normalize-url": "^4.3.0",
-		"url-regex": "^5.0.0"
+		"re2": "^1.15.4",
+		"url-regex-safe": "0.0.5"
 	},
 	"devDependencies": {
 		"ava": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=8"
+		"node": ">=10.12.0"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"


### PR DESCRIPTION
- Replaced `url-regex` dependency with `url-regex-safe` in response to CVE-2020-7661
- Updated minimum required node version to v10.12.0 to maintain compatibility with `url-regex-safe`  
- Added `re2` dependency  
- Switched to global URL variable  
- Converted regex capture groups to named capture groups

Fixes #59