### PR TITLE
Fix docs for `requireSchemeOrWww` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ declare namespace getUrls {
 
 		Does not affect URLs in query parameters if using the `extractFromQueryString` option.
 
-		@default true
+		@default false
 		*/
 		readonly requireSchemeOrWww?: boolean;
 	}

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ Exclude URLs that match URLs in the given array.
 #### requireSchemeOrWww
 
 Type: `boolean`\
-Default: `true`
+Default: `false`
 
 Require URLs to have a scheme or leading `www.` to be considered an URL. When `false`, matches against a list of valid TLDs, so it will match URLs like `unicorn.education`.
 


### PR DESCRIPTION
This flag appears to be passed directly to url-regex-safe as the `strict` parameter, and the default for `strict` is `false`:

- get-urls: https://github.com/sindresorhus/get-urls/blob/80d0116fa1bd102121973539d309f2afc482ea70/index.js#L35-L38
- url-regex-safe: https://github.com/niftylettuce/url-regex-safe/blob/542654bc7e2f53ee514724cbe9fb19912794b9d6/src/index.js#L13