### PR TITLE
Used the parens param of the url-regex-safe lib

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,13 @@ declare namespace getUrls {
 		@default false
 		*/
 		readonly requireSchemeOrWww?: boolean;
+
+		/**
+		Expect URLs with parenthesis to parse it correctly.
+
+		@default false
+		*/
+		readonly parseParenthesis?: boolean;
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -32,10 +32,18 @@ module.exports = (text, options = {}) => {
 		} catch {}
 	};
 
+	const urlRegexOptions = {};
+
+	if (options.requireSchemeOrWww !== undefined) {
+		urlRegexOptions.strict = options.requireSchemeOrWww;
+	}
+
+	if (options.parseParenthesis) {
+		urlRegexOptions.parens = options.parseParenthesis;
+	}
+
 	const urls = text.match(
-		urlRegex(options.requireSchemeOrWww === undefined ? undefined : {
-			strict: options.requireSchemeOrWww
-		})
+		urlRegex(Object.keys(urlRegexOptions) === 0 ? undefined : urlRegexOptions)
 	) || [];
 	for (const url of urls) {
 		add(url);

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,12 @@ Default: `false`
 Require URLs to have a scheme or leading `www.` to be considered an URL. When `false`, matches against a list of valid TLDs, so it will match URLs like `unicorn.education`.
 
 Does not affect URLs in query parameters if using the `extractFromQueryString` option.
+#### parseParenthesis
+
+Type: `boolean`\
+Default: `false`
+
+Expect URLs with parenthesis to parse it correctly.
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -201,3 +201,15 @@ test('handles Markdown', t => {
 		])
 	);
 });
+
+test('handles URLs with parenthesis', t => {
+	const text = 'Accessed on 4/12/2021 at https://website.org/What-is-MS/Types-of-MS/Clinically-Isolated-Syndrome-(CIS) and one more URL https://website.org/What-is-MS/Types-of-MS/Clinically-Isolated-Syndrome-(CIS)/some-path';
+
+	t.deepEqual(
+		getUrls(text, {parseParenthesis: true}),
+		new Set([
+			'https://website.org/What-is-MS/Types-of-MS/Clinically-Isolated-Syndrome-(CIS)',
+			'https://website.org/What-is-MS/Types-of-MS/Clinically-Isolated-Syndrome-(CIS)/some-path'
+		])
+	);
+});


### PR DESCRIPTION
Fixed bug with parsing URLs with parenthesis like `http://website.com/path-with-(parenthesis)`

This behavior described in the url-regex-safe documentation

Fixes #79