### PR TITLE
BREAKING CHANGE: Bump version of normalize-url to 8, dependency bumps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
           - 14
           - 12
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import {Options as NormalizeUrlOptions} from 'normalize-url';
+import type {Options as NormalizeUrlOptions} from 'normalize-url';
 
 export interface Options extends NormalizeUrlOptions {
 	/**

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ export default function getUrls(text, options = {}) {
 		throw new TypeError(`The \`text\` argument should be a string, got ${typeof text}`);
 	}
 
-	if (typeof options.exclude !== 'undefined' && !Array.isArray(options.exclude)) {
+	if (options.exclude !== undefined && !Array.isArray(options.exclude)) {
 		throw new TypeError('The `exclude` option must be an array');
 	}
 
@@ -50,8 +50,8 @@ export default function getUrls(text, options = {}) {
 	}
 
 	for (const excludedItem of options.exclude || []) {
+		const regex = new RegExp(excludedItem);
 		for (const item of returnValue) {
-			const regex = new RegExp(excludedItem);
 			if (regex.test(item)) {
 				returnValue.delete(item);
 			}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,4 +7,4 @@ const text
 expectType<Set<string>>(getUrls(text));
 expectType<Set<string>>(getUrls(text, {extractFromQueryString: true}));
 expectType<Set<string>>(getUrls(text, {exclude: ['foo']}));
-expectType<Set<string>>(getUrls(text, {defaultProtocol: 'ftp'}));
+expectType<Set<string>>(getUrls(text, {defaultProtocol: 'http'}));

--- a/package.json
+++ b/package.json
@@ -33,13 +33,18 @@
 		"string"
 	],
 	"dependencies": {
-		"normalize-url": "^7.0.2",
-		"re2": "^1.17.2",
+		"normalize-url": "^8.0.0",
+		"re2": "^1.19.1",
 		"url-regex-safe": "^3.0.0"
 	},
 	"devDependencies": {
-		"ava": "^4.0.1",
-		"tsd": "^0.19.1",
-		"xo": "^0.47.0"
+		"ava": "^5.3.1",
+		"tsd": "^0.28.1",
+		"xo": "^0.54.2"
+	},
+	"xo": {
+		"rules": {
+			"@typescript-eslint/consistent-type-definitions": "off"
+		}
 	}
 }

--- a/test.js
+++ b/test.js
@@ -23,7 +23,7 @@ test('do not get nested urls from query strings', t => {
 	t.deepEqual(
 		getUrls(text),
 		new Set([
-			'http://awin1.com/cread.php?a=b&p=https%3A%2F%2Fuk.hotels.com%2Fhotel%2Fdetails.html%3Ftab%3Ddescription%26hotelId%3D287452%26q-localised-check-in%3D15%2F12%2F2017%26q-localised-check-out%3D19%2F12%2F2017%26q-room-0-adults%3D2%26q-room-0-children%3D0%26locale%3Den_GB%26pos%3DHCOM_UK',
+			'http://awin1.com/cread.php?a=b&p=https://uk.hotels.com/hotel/details.html?tab=description&hotelId=287452&q-localised-check-in=15/12/2017&q-localised-check-out=19/12/2017&q-room-0-adults=2&q-room-0-children=0&locale=en_GB&pos=HCOM_UK',
 		]),
 	);
 });
@@ -34,8 +34,8 @@ test('get nested urls from query strings', t => {
 	t.deepEqual(
 		getUrls(text, {extractFromQueryString: true}),
 		new Set([
-			'http://awin1.com/cread.php?a=b&p=https%3A%2F%2Fuk.hotels.com%2Fhotel%2Fdetails.html%3Ftab%3Ddescription%26hotelId%3D287452%26q-localised-check-in%3D15%2F12%2F2017%26q-localised-check-out%3D19%2F12%2F2017%26q-room-0-adults%3D2%26q-room-0-children%3D0%26locale%3Den_GB%26pos%3DHCOM_UK',
-			'https://uk.hotels.com/hotel/details.html?hotelId=287452&locale=en_GB&pos=HCOM_UK&q-localised-check-in=15%2F12%2F2017&q-localised-check-out=19%2F12%2F2017&q-room-0-adults=2&q-room-0-children=0&tab=description',
+			'http://awin1.com/cread.php?a=b&p=https://uk.hotels.com/hotel/details.html?tab=description&hotelId=287452&q-localised-check-in=15/12/2017&q-localised-check-out=19/12/2017&q-room-0-adults=2&q-room-0-children=0&locale=en_GB&pos=HCOM_UK',
+			'https://uk.hotels.com/hotel/details.html?hotelId=287452&locale=en_GB&pos=HCOM_UK&q-localised-check-in=15/12/2017&q-localised-check-out=19/12/2017&q-room-0-adults=2&q-room-0-children=0&tab=description',
 		]),
 	);
 });
@@ -127,8 +127,8 @@ test('get schemeless url from query string', t => {
 			extractFromQueryString: true,
 		}),
 		new Set([
-			'http://awin1.com/cread.php?a=b&p=%2F%2Fuk.hotels.com%2Fhotel%2Fdetails.html%3Ftab%3Ddescription%26hotelId%3D287452%26q-localised-check-in%3D15%2F12%2F2017%26q-localised-check-out%3D19%2F12%2F2017%26q-room-0-adults%3D2%26q-room-0-children%3D0%26locale%3Den_GB%26pos%3DHCOM_UK',
-			'http://uk.hotels.com/hotel/details.html?hotelId=287452&locale=en_GB&pos=HCOM_UK&q-localised-check-in=15%2F12%2F2017&q-localised-check-out=19%2F12%2F2017&q-room-0-adults=2&q-room-0-children=0&tab=description',
+			'http://awin1.com/cread.php?a=b&p=//uk.hotels.com/hotel/details.html?tab=description&hotelId=287452&q-localised-check-in=15/12/2017&q-localised-check-out=19/12/2017&q-room-0-adults=2&q-room-0-children=0&locale=en_GB&pos=HCOM_UK',
+			'http://uk.hotels.com/hotel/details.html?hotelId=287452&locale=en_GB&pos=HCOM_UK&q-localised-check-in=15/12/2017&q-localised-check-out=19/12/2017&q-room-0-adults=2&q-room-0-children=0&tab=description',
 		]),
 	);
 });


### PR DESCRIPTION
Bumps dependency versions, fixes lint errors

There's a breaking change in normalize-url v7.0.3 around url query strings - https://github.com/sindresorhus/normalize-url/pull/158 which I figured should be a major version bump